### PR TITLE
Replay and Skip Bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # mpv-sub-pause
 
-A mpv script that automatically pauses after each subtitle line.
+An mpv script that automatically pauses after each subtitle line.
 Mostly intended for language learning.
 
-The default key binding for toggling auto-pause is `n`.  
-The default key binding for skipping the next subtitle pause is `Ctrl+Space`.  
-The default key binding for repeating the current subtitle is `Ctrl+r`.  
-The default key binding for repeating the current subtitle without pausing the subtitle is `Alt+r`.  
-To use a custom key add a line like the following to your `input.conf`:
+The default key bindings are:
 
-```
-X script-binding sub-pause-toggle
-X script-binding sub-pause-toggle-skip
-X script-binding sub-pause-toggle-replay
-X script-binding sub-pause-toggle-replay-skip
-```
+- `n`: toggle auto-pause (`sub-pause-toggle`)
+- `Shift+SPACE`: replay active line, always available (`sub-pause-replay`)
+- `Ctrl+SPACE`: skip next pause (`sub-pause-skip-next`)
+
+To use custom key bindings add lines like the following to your `input.conf`
+(where `action_name` is the value in parentheses in the above list):
+
+```X script-binding <action_name>```
+
+If you want a binding for both replaying and skipping add a line like this:
+
+```Ctrl+Alt+SPACE script-binding sub-pause-replay; script-binding sub-pause-skip-next```
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # mpv-sub-pause
 
-An mpv script that automatically pauses after each subtitle line.
+A mpv script that automatically pauses after each subtitle line.
 Mostly intended for language learning.
 
 The default key binding for toggling auto-pause is `n`.  
+The default key binding for skipping the next subtitle pause is `Ctrl+Space`.  
+The default key binding for repeating the current subtitle is `Ctrl+r`.  
+The default key binding for repeating the current subtitle without pausing the subtitle is `Alt+r`.  
 To use a custom key add a line like the following to your `input.conf`:
 
 ```
 X script-binding sub-pause-toggle
+X script-binding sub-pause-toggle-skip
+X script-binding sub-pause-toggle-replay
+X script-binding sub-pause-toggle-replay-skip
 ```
 
 ## Known Issues

--- a/sub-pause.lua
+++ b/sub-pause.lua
@@ -39,14 +39,14 @@ mp.add_key_binding("n", "sub-pause-toggle", function()
 	active = not active
 end)
 
+mp.add_key_binding("Ctrl+Space", "sub-pause-toggle-skip", function()
+	skip_next = not skip_next
+end)
+
 mp.add_key_binding("Ctrl+r", "sub-pause-toggle-replay", function()
 	replay_sub(false)
 end)
 
 mp.add_key_binding("Alt+r", "sub-pause-toggle-replay-skip", function()
 	replay_sub(true)
-end)
-
-mp.add_key_binding("Ctrl+Space", "sub-pause-toggle-skip", function()
-	skip_next = not skip_next
 end)

--- a/sub-pause.lua
+++ b/sub-pause.lua
@@ -1,10 +1,11 @@
 local active = false
-local pause_at = 0
 local skip_next = false
+local pause_at = 0
 
 local function handle_tick(prop_name, time_pos)
 	if time_pos ~= nil and pause_at - time_pos < 0.1 then
-		if skip_next then skip_next = false else mp.set_property("pause", "yes") end
+		if skip_next then skip_next = false
+		else mp.set_property("pause", "yes") end
 		mp.unobserve_property(handle_tick)
 	end
 end
@@ -17,17 +18,17 @@ local function handle_sub_text_change(prop_name, sub_text)
 	end
 end
 
-local function replay_sub(skip)
- 	local sub_start = mp.get_property_number('sub-start')
+local function replay_sub()
+	local sub_start = mp.get_property_number('sub-start')
 	if sub_start ~= nil then
-		skip_next = skip
-		mp.set_property("time-pos", sub_start + mp.get_property_number('sub-delay') - 0.1)
+		mp.set_property("time-pos", sub_start + mp.get_property_number('sub-delay'))
 		mp.set_property("pause", "no")
 	end 
 end
 
 mp.add_key_binding("n", "sub-pause-toggle", function()
 	if active then
+		pause_at = 0
 		skip_next = false
 		mp.unobserve_property(handle_sub_text_change)
 		mp.unobserve_property(handle_tick)
@@ -39,14 +40,6 @@ mp.add_key_binding("n", "sub-pause-toggle", function()
 	active = not active
 end)
 
-mp.add_key_binding("Ctrl+Space", "sub-pause-toggle-skip", function()
-	skip_next = not skip_next
-end)
+mp.add_key_binding("Ctrl+SPACE", "sub-pause-skip-next", function() skip_next = true end)
 
-mp.add_key_binding("Ctrl+r", "sub-pause-toggle-replay", function()
-	replay_sub(false)
-end)
-
-mp.add_key_binding("Alt+r", "sub-pause-toggle-replay-skip", function()
-	replay_sub(true)
-end)
+mp.add_key_binding("Alt+SPACE", "sub-pause-replay", function() replay_sub() end)

--- a/sub-pause.lua
+++ b/sub-pause.lua
@@ -1,9 +1,10 @@
 local active = false
 local pause_at = 0
+local skip_next = false
 
 local function handle_tick(prop_name, time_pos)
 	if time_pos ~= nil and pause_at - time_pos < 0.1 then
-		mp.set_property("pause", "yes")
+		if skip_next then skip_next = false else mp.set_property("pause", "yes") end
 		mp.unobserve_property(handle_tick)
 	end
 end
@@ -16,8 +17,18 @@ local function handle_sub_text_change(prop_name, sub_text)
 	end
 end
 
+local function replay_sub(skip)
+ 	local sub_start = mp.get_property_number('sub-start')
+	if sub_start ~= nil then
+		skip_next = skip
+		mp.set_property("time-pos", sub_start + mp.get_property_number('sub-delay') - 0.1)
+		mp.set_property("pause", "no")
+	end 
+end
+
 mp.add_key_binding("n", "sub-pause-toggle", function()
 	if active then
+		skip_next = false
 		mp.unobserve_property(handle_sub_text_change)
 		mp.unobserve_property(handle_tick)
 		mp.osd_message("Subtitle pausing disabled")
@@ -26,4 +37,16 @@ mp.add_key_binding("n", "sub-pause-toggle", function()
 		mp.osd_message("Subtitle pausing enabled")
 	end
 	active = not active
+end)
+
+mp.add_key_binding("Ctrl+r", "sub-pause-toggle-replay", function()
+	replay_sub(false)
+end)
+
+mp.add_key_binding("Alt+r", "sub-pause-toggle-replay-skip", function()
+	replay_sub(true)
+end)
+
+mp.add_key_binding("Ctrl+Space", "sub-pause-toggle-skip", function()
+	skip_next = not skip_next
 end)


### PR DESCRIPTION
I am a new mpv user so maybe i simply missed it - but i think there is no keybind / command for replaying the current Subtitle but only to seek the to previous / next one?

Skipping one pause is also a common Use Case i guess either because you understood everything or the line just consiststs out of sounds like laughing or similar.

PR adds 3 new Keybinds: One which skips the next pause from this script, one which replays the current Subtitle if one is currently available and one which replays the Subtitle and skip the next pause.